### PR TITLE
Use network packets for Mega Randomizer options screen

### DIFF
--- a/src/main/java/org/stevefal/megarandomizer/MegaRandomizer1_7_10.java
+++ b/src/main/java/org/stevefal/megarandomizer/MegaRandomizer1_7_10.java
@@ -10,6 +10,7 @@ import org.stevefal.megarandomizer.event.ClientEvents;
 import org.stevefal.megarandomizer.event.ServerEvents;
 import org.stevefal.megarandomizer.gamerules.MegaGameRules;
 import org.stevefal.megarandomizer.megadrops.RandomDrops;
+import org.stevefal.megarandomizer.networking.MegaMessages;
 
 @Mod(modid = MegaRandomizer1_7_10.MODID, version = MegaRandomizer1_7_10.VERSION)
 public class MegaRandomizer1_7_10
@@ -22,6 +23,8 @@ public class MegaRandomizer1_7_10
 
         MinecraftForge.EVENT_BUS.register(new ServerEvents());
         MinecraftForge.EVENT_BUS.register(new ClientEvents());
+
+        MegaMessages.register();
     }
 
 

--- a/src/main/java/org/stevefal/megarandomizer/event/ClientEvents.java
+++ b/src/main/java/org/stevefal/megarandomizer/event/ClientEvents.java
@@ -7,12 +7,15 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiIngameMenu;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import org.stevefal.megarandomizer.gui.ModPauseScreen;
+import org.stevefal.megarandomizer.networking.MegaMessages;
+import org.stevefal.megarandomizer.networking.packets.RequestGameRulesSyncC2SPacket;
 
 @SideOnly(Side.CLIENT)
 public class ClientEvents {
 
     @SubscribeEvent
-    public void onPauseMenuTruggered(GuiScreenEvent.InitGuiEvent event) {
+    public void onPauseMenuTriggered(GuiScreenEvent.InitGuiEvent event) {
+        MegaMessages.sendToServer(new RequestGameRulesSyncC2SPacket());
         if (event.gui instanceof GuiIngameMenu) {
             Minecraft.getMinecraft().displayGuiScreen(new ModPauseScreen((GuiIngameMenu) event.gui));
         }

--- a/src/main/java/org/stevefal/megarandomizer/gui/MegaRandomOptionsScreen.java
+++ b/src/main/java/org/stevefal/megarandomizer/gui/MegaRandomOptionsScreen.java
@@ -5,6 +5,8 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.multiplayer.WorldClient;
 import org.stevefal.megarandomizer.gamerules.MegaGameRules;
+import org.stevefal.megarandomizer.networking.MegaMessages;
+import org.stevefal.megarandomizer.networking.packets.SetGameRulesC2SPacket;
 
 public class MegaRandomOptionsScreen extends GuiScreen {
 
@@ -32,20 +34,41 @@ public class MegaRandomOptionsScreen extends GuiScreen {
                 getButtonString(MegaGameRules.RULE_DO_PLAYER_RANDOM_DROPS, "Player")));
 
         this.buttonList.add(new GuiButton(4, this.width / 2 - 100, this.height / 4 + 96 - b0, "Done"));
+
     }
 
 
     protected void actionPerformed(GuiButton button) {
         switch (button.id) {
             case 0:
-                System.out.println("Test button clicked!!");
                 // Blocks
+                WORLD.getGameRules().setOrCreateGameRule(MegaGameRules.RULE_DO_BLOCK_RANDOM_DROPS,
+                        String.valueOf(!WORLD.getGameRules().getGameRuleBooleanValue(MegaGameRules.RULE_DO_BLOCK_RANDOM_DROPS)));
+                initGui();
+                MegaMessages.sendToServer(new SetGameRulesC2SPacket(
+                        WORLD.getGameRules().getGameRuleBooleanValue(MegaGameRules.RULE_DO_BLOCK_RANDOM_DROPS),
+                        WORLD.getGameRules().getGameRuleBooleanValue(MegaGameRules.RULE_DO_ENTITY_RANDOM_DROPS),
+                        WORLD.getGameRules().getGameRuleBooleanValue(MegaGameRules.RULE_DO_PLAYER_RANDOM_DROPS)));
                 break;
             case 1:
                 // Entities
+                WORLD.getGameRules().setOrCreateGameRule(MegaGameRules.RULE_DO_ENTITY_RANDOM_DROPS,
+                        String.valueOf(!WORLD.getGameRules().getGameRuleBooleanValue(MegaGameRules.RULE_DO_ENTITY_RANDOM_DROPS)));
+                initGui();
+                MegaMessages.sendToServer(new SetGameRulesC2SPacket(
+                        WORLD.getGameRules().getGameRuleBooleanValue(MegaGameRules.RULE_DO_BLOCK_RANDOM_DROPS),
+                        WORLD.getGameRules().getGameRuleBooleanValue(MegaGameRules.RULE_DO_ENTITY_RANDOM_DROPS),
+                        WORLD.getGameRules().getGameRuleBooleanValue(MegaGameRules.RULE_DO_PLAYER_RANDOM_DROPS)));
                 break;
             case 2:
                 // Players
+                WORLD.getGameRules().setOrCreateGameRule(MegaGameRules.RULE_DO_PLAYER_RANDOM_DROPS,
+                        String.valueOf(!WORLD.getGameRules().getGameRuleBooleanValue(MegaGameRules.RULE_DO_PLAYER_RANDOM_DROPS)));
+                initGui();
+                MegaMessages.sendToServer(new SetGameRulesC2SPacket(
+                        WORLD.getGameRules().getGameRuleBooleanValue(MegaGameRules.RULE_DO_BLOCK_RANDOM_DROPS),
+                        WORLD.getGameRules().getGameRuleBooleanValue(MegaGameRules.RULE_DO_ENTITY_RANDOM_DROPS),
+                        WORLD.getGameRules().getGameRuleBooleanValue(MegaGameRules.RULE_DO_PLAYER_RANDOM_DROPS)));
                 break;
             case 3:
             case 4:
@@ -55,7 +78,7 @@ public class MegaRandomOptionsScreen extends GuiScreen {
     }
 
     private String getButtonString(String megaGameRule, String ruleName) {
-        boolean ruleValue = this.WORLD.getGameRules().getGameRuleBooleanValue(megaGameRule);
+        boolean ruleValue = WORLD.getGameRules().getGameRuleBooleanValue(megaGameRule);
         String onOff = ruleValue ? "ON" : "Off";
         return "Randomize " + ruleName + " Drops: " + onOff;
     }

--- a/src/main/java/org/stevefal/megarandomizer/gui/ModPauseScreen.java
+++ b/src/main/java/org/stevefal/megarandomizer/gui/ModPauseScreen.java
@@ -8,6 +8,8 @@ import net.minecraft.client.gui.achievement.GuiAchievements;
 import net.minecraft.client.gui.achievement.GuiStats;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.client.resources.I18n;
+import org.stevefal.megarandomizer.networking.MegaMessages;
+import org.stevefal.megarandomizer.networking.packets.RequestGameRulesSyncC2SPacket;
 
 @SideOnly(Side.CLIENT)
 public class ModPauseScreen extends GuiScreen {
@@ -85,6 +87,7 @@ public class ModPauseScreen extends GuiScreen {
                 FMLClientHandler.instance().showInGameModOptions(this.normalMenu);
                 break;
             case 14:
+
                 this.mc.displayGuiScreen(new MegaRandomOptionsScreen(this, this.mc.theWorld));
                 break;
         }

--- a/src/main/java/org/stevefal/megarandomizer/networking/MegaMessages.java
+++ b/src/main/java/org/stevefal/megarandomizer/networking/MegaMessages.java
@@ -7,6 +7,7 @@ import cpw.mods.fml.relauncher.Side;
 import net.minecraft.entity.player.EntityPlayerMP;
 import org.stevefal.megarandomizer.MegaRandomizer1_7_10;
 import org.stevefal.megarandomizer.networking.packets.GameRulesSyncS2CPacket;
+import org.stevefal.megarandomizer.networking.packets.RequestGameRulesSyncC2SPacket;
 import org.stevefal.megarandomizer.networking.packets.SetGameRulesC2SPacket;
 
 public class MegaMessages {
@@ -24,6 +25,7 @@ public class MegaMessages {
 
         /* To Server */
         netReg.registerMessage(SetGameRulesC2SPacket.Handler.class, SetGameRulesC2SPacket.class, id(), Side.SERVER);
+        netReg.registerMessage(RequestGameRulesSyncC2SPacket.Handler.class, RequestGameRulesSyncC2SPacket.class, id(), Side.SERVER);
 
 
         /* To Client */

--- a/src/main/java/org/stevefal/megarandomizer/networking/MegaMessages.java
+++ b/src/main/java/org/stevefal/megarandomizer/networking/MegaMessages.java
@@ -1,0 +1,41 @@
+package org.stevefal.megarandomizer.networking;
+
+import cpw.mods.fml.common.network.NetworkRegistry;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.SimpleNetworkWrapper;
+import cpw.mods.fml.relauncher.Side;
+import net.minecraft.entity.player.EntityPlayerMP;
+import org.stevefal.megarandomizer.MegaRandomizer1_7_10;
+import org.stevefal.megarandomizer.networking.packets.GameRulesSyncS2CPacket;
+import org.stevefal.megarandomizer.networking.packets.SetGameRulesC2SPacket;
+
+public class MegaMessages {
+
+    private static SimpleNetworkWrapper INSTANCE;
+    private static int packetId = 0;
+
+    private static int id() {
+        return packetId++;
+    }
+
+    public static void register() {
+        SimpleNetworkWrapper netReg = NetworkRegistry.INSTANCE.newSimpleChannel(MegaRandomizer1_7_10.MODID);
+        INSTANCE = netReg;
+
+        /* To Server */
+        netReg.registerMessage(SetGameRulesC2SPacket.Handler.class, SetGameRulesC2SPacket.class, id(), Side.SERVER);
+
+
+        /* To Client */
+        netReg.registerMessage(GameRulesSyncS2CPacket.Handler.class, GameRulesSyncS2CPacket.class, id(), Side.CLIENT);
+    }
+
+    public static void sendToServer(IMessage message) {
+        INSTANCE.sendToServer(message);
+    }
+
+    public static void sendToPlayer(IMessage message, EntityPlayerMP player) {
+        INSTANCE.sendTo(message, player);
+    }
+
+}

--- a/src/main/java/org/stevefal/megarandomizer/networking/packets/GameRulesSyncS2CPacket.java
+++ b/src/main/java/org/stevefal/megarandomizer/networking/packets/GameRulesSyncS2CPacket.java
@@ -7,6 +7,7 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.world.World;
+import org.stevefal.megarandomizer.gamerules.MegaGameRules;
 
 public class GameRulesSyncS2CPacket implements IMessage {
 
@@ -41,6 +42,9 @@ public class GameRulesSyncS2CPacket implements IMessage {
         @Override
         public IMessage onMessage(GameRulesSyncS2CPacket gameRulesSyncS2CPacket, MessageContext messageContext) {
             WorldClient worldClient = Minecraft.getMinecraft().theWorld;
+            worldClient.getGameRules().setOrCreateGameRule(MegaGameRules.RULE_DO_BLOCK_RANDOM_DROPS, String.valueOf(gameRulesSyncS2CPacket.isDoBlockRandomDrops));
+            worldClient.getGameRules().setOrCreateGameRule(MegaGameRules.RULE_DO_ENTITY_RANDOM_DROPS, String.valueOf(gameRulesSyncS2CPacket.isDoEntityRandomDrops));
+            worldClient.getGameRules().setOrCreateGameRule(MegaGameRules.RULE_DO_PLAYER_RANDOM_DROPS, String.valueOf(gameRulesSyncS2CPacket.isDoPlayerRandomDrops));
 
 
             return null;

--- a/src/main/java/org/stevefal/megarandomizer/networking/packets/GameRulesSyncS2CPacket.java
+++ b/src/main/java/org/stevefal/megarandomizer/networking/packets/GameRulesSyncS2CPacket.java
@@ -6,7 +6,6 @@ import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.WorldClient;
-import net.minecraft.world.World;
 import org.stevefal.megarandomizer.gamerules.MegaGameRules;
 
 public class GameRulesSyncS2CPacket implements IMessage {

--- a/src/main/java/org/stevefal/megarandomizer/networking/packets/GameRulesSyncS2CPacket.java
+++ b/src/main/java/org/stevefal/megarandomizer/networking/packets/GameRulesSyncS2CPacket.java
@@ -1,0 +1,50 @@
+package org.stevefal.megarandomizer.networking.packets;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.WorldClient;
+import net.minecraft.world.World;
+
+public class GameRulesSyncS2CPacket implements IMessage {
+
+    private boolean isDoBlockRandomDrops;
+    private boolean isDoEntityRandomDrops;
+    private boolean isDoPlayerRandomDrops;
+    public GameRulesSyncS2CPacket(){}
+
+    public GameRulesSyncS2CPacket(boolean isDoBlocks, boolean isDoEntities, boolean isDoPlayer) {
+        this.isDoBlockRandomDrops = isDoBlocks;
+        this.isDoEntityRandomDrops = isDoEntities;
+        this.isDoPlayerRandomDrops = isDoPlayer;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf byteBuf) {
+        this.isDoBlockRandomDrops = byteBuf.readBoolean();
+        this.isDoEntityRandomDrops = byteBuf.readBoolean();
+        this.isDoPlayerRandomDrops = byteBuf.readBoolean();
+    }
+
+    @Override
+    public void toBytes(ByteBuf byteBuf) {
+        byteBuf.writeBoolean(isDoBlockRandomDrops);
+        byteBuf.writeBoolean(isDoEntityRandomDrops);
+        byteBuf.writeBoolean(isDoPlayerRandomDrops);
+    }
+
+    public static class Handler implements IMessageHandler<GameRulesSyncS2CPacket, IMessage> {
+
+
+        @Override
+        public IMessage onMessage(GameRulesSyncS2CPacket gameRulesSyncS2CPacket, MessageContext messageContext) {
+            WorldClient worldClient = Minecraft.getMinecraft().theWorld;
+
+
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/org/stevefal/megarandomizer/networking/packets/RequestGameRulesSyncC2SPacket.java
+++ b/src/main/java/org/stevefal/megarandomizer/networking/packets/RequestGameRulesSyncC2SPacket.java
@@ -1,0 +1,35 @@
+package org.stevefal.megarandomizer.networking.packets;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.world.GameRules;
+import org.stevefal.megarandomizer.gamerules.MegaGameRules;
+import org.stevefal.megarandomizer.networking.MegaMessages;
+
+public class RequestGameRulesSyncC2SPacket implements IMessage {
+
+ public RequestGameRulesSyncC2SPacket() {}
+
+    @Override
+    public void fromBytes(ByteBuf byteBuf) {
+
+    }
+
+    @Override
+    public void toBytes(ByteBuf byteBuf) {
+
+    }
+
+    public static class Handler implements IMessageHandler<RequestGameRulesSyncC2SPacket, IMessage> {
+        @Override
+        public IMessage onMessage(RequestGameRulesSyncC2SPacket requestGameRulesSyncC2SPacket, MessageContext messageContext) {
+            GameRules gameRules = messageContext.getServerHandler().playerEntity.getEntityWorld().getGameRules();
+            MegaMessages.sendToPlayer(new GameRulesSyncS2CPacket(gameRules.getGameRuleBooleanValue(MegaGameRules.RULE_DO_BLOCK_RANDOM_DROPS),
+                    gameRules.getGameRuleBooleanValue(MegaGameRules.RULE_DO_ENTITY_RANDOM_DROPS),
+                    gameRules.getGameRuleBooleanValue(MegaGameRules.RULE_DO_PLAYER_RANDOM_DROPS)), messageContext.getServerHandler().playerEntity);
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/stevefal/megarandomizer/networking/packets/SetGameRulesC2SPacket.java
+++ b/src/main/java/org/stevefal/megarandomizer/networking/packets/SetGameRulesC2SPacket.java
@@ -1,0 +1,54 @@
+package org.stevefal.megarandomizer.networking.packets;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.world.World;
+import org.stevefal.megarandomizer.gamerules.MegaGameRules;
+
+public class SetGameRulesC2SPacket implements IMessage {
+
+    private boolean isDoBlockRandomDrops;
+    private boolean isDoEntityRandomDrops;
+    private boolean isDoPlayerRandomDrops;
+
+    public SetGameRulesC2SPacket() {}
+
+    public SetGameRulesC2SPacket(boolean isDoBlockRandomDrops, boolean isDoEntityRandomDrops, boolean isDoPlayerRandomDrops) {
+        this.isDoBlockRandomDrops = isDoBlockRandomDrops;
+        this.isDoEntityRandomDrops = isDoEntityRandomDrops;
+        this.isDoPlayerRandomDrops = isDoPlayerRandomDrops;
+    }
+
+
+    @Override
+    public void fromBytes(ByteBuf byteBuf) {
+        this.isDoBlockRandomDrops = byteBuf.readBoolean();
+        this.isDoEntityRandomDrops = byteBuf.readBoolean();
+        this.isDoPlayerRandomDrops = byteBuf.readBoolean();
+
+    }
+
+    @Override
+    public void toBytes(ByteBuf byteBuf) {
+        byteBuf.writeBoolean(isDoBlockRandomDrops);
+        byteBuf.writeBoolean(isDoEntityRandomDrops);
+        byteBuf.writeBoolean(isDoPlayerRandomDrops);
+    }
+
+    public static class Handler implements IMessageHandler<SetGameRulesC2SPacket, IMessage> {
+
+        @Override
+        public IMessage onMessage(SetGameRulesC2SPacket setGameRulesC2SPacket, MessageContext messageContext) {
+            World world = messageContext.getServerHandler().playerEntity.getEntityWorld();
+            world.getGameRules().setOrCreateGameRule(MegaGameRules.RULE_DO_BLOCK_RANDOM_DROPS, String.valueOf(setGameRulesC2SPacket.isDoBlockRandomDrops));
+            world.getGameRules().setOrCreateGameRule(MegaGameRules.RULE_DO_ENTITY_RANDOM_DROPS, String.valueOf(setGameRulesC2SPacket.isDoEntityRandomDrops));
+            world.getGameRules().setOrCreateGameRule(MegaGameRules.RULE_DO_PLAYER_RANDOM_DROPS, String.valueOf(setGameRulesC2SPacket.isDoPlayerRandomDrops));
+
+            return null;
+        }
+    }
+
+
+}

--- a/src/main/java/org/stevefal/megarandomizer/networking/packets/SetGameRulesC2SPacket.java
+++ b/src/main/java/org/stevefal/megarandomizer/networking/packets/SetGameRulesC2SPacket.java
@@ -6,6 +6,7 @@ import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.world.World;
 import org.stevefal.megarandomizer.gamerules.MegaGameRules;
+import org.stevefal.megarandomizer.networking.MegaMessages;
 
 public class SetGameRulesC2SPacket implements IMessage {
 
@@ -13,7 +14,8 @@ public class SetGameRulesC2SPacket implements IMessage {
     private boolean isDoEntityRandomDrops;
     private boolean isDoPlayerRandomDrops;
 
-    public SetGameRulesC2SPacket() {}
+    public SetGameRulesC2SPacket() {
+    }
 
     public SetGameRulesC2SPacket(boolean isDoBlockRandomDrops, boolean isDoEntityRandomDrops, boolean isDoPlayerRandomDrops) {
         this.isDoBlockRandomDrops = isDoBlockRandomDrops;
@@ -45,6 +47,10 @@ public class SetGameRulesC2SPacket implements IMessage {
             world.getGameRules().setOrCreateGameRule(MegaGameRules.RULE_DO_BLOCK_RANDOM_DROPS, String.valueOf(setGameRulesC2SPacket.isDoBlockRandomDrops));
             world.getGameRules().setOrCreateGameRule(MegaGameRules.RULE_DO_ENTITY_RANDOM_DROPS, String.valueOf(setGameRulesC2SPacket.isDoEntityRandomDrops));
             world.getGameRules().setOrCreateGameRule(MegaGameRules.RULE_DO_PLAYER_RANDOM_DROPS, String.valueOf(setGameRulesC2SPacket.isDoPlayerRandomDrops));
+
+            MegaMessages.sendToPlayer(new GameRulesSyncS2CPacket(setGameRulesC2SPacket.isDoBlockRandomDrops,
+                            setGameRulesC2SPacket.isDoEntityRandomDrops, setGameRulesC2SPacket.isDoPlayerRandomDrops),
+                    messageContext.getServerHandler().playerEntity);
 
             return null;
         }


### PR DESCRIPTION
- Mega Randomizer options screen needs to communicate with server to sync game rules data
- Create network packets for syncing data between sides
- Create channel for packets and register
- Have client send packet to request current Mega Randomizer game rule values when menu screen is triggered
- When menu screen is active, game is paused, including network packets, so client must receive data before Mega Randomizer option screen is active.
- Set gamerule value on client world instance when relevant button is clicked in Mega Randomizer options screen
- Then refresh the screen to update the button
- Then trigger network packet(s) to update server with new gamerule value(s) (once game unpauses)